### PR TITLE
Adding custom content-types, sections and api extensions following foresight videos

### DIFF
--- a/cms/faststore/content-types.json
+++ b/cms/faststore/content-types.json
@@ -1,0 +1,51 @@
+[
+  {
+   "id": "customPage",
+   "name": "Custom Page Angela",
+   "configurationSchemaSets": [
+     {
+       "name": "Settings",
+       "configurations": [
+         {
+           "name": "seo",
+           "schema": {
+             "title": "Settings",
+             "description": "Search Engine Optimization options",
+             "type": "object",
+             "widget": {
+               "ui:ObjectFieldTemplate": "GoogleSeoPreview"
+             },
+             "required": [
+               "slug",
+               "title",
+               "description"
+             ],
+             "properties": {
+               "slug": {
+                 "title": "Path",
+                 "type": "string",
+                 "default": "/"
+               },
+               "title": {
+                 "title": "Default page title",
+                 "description": "Display this title when no other title is available",
+                 "type": "string",
+                 "default": "FastStore Starter"
+               },
+               "description": {
+                 "title": "Meta tag description",
+                 "type": "string",
+                 "default": "A beautifully designed store"
+               },
+               "canonical": {
+                 "title": "Canonical url for the page",
+                 "type": "string"
+               }
+             }
+           }
+         }
+       ]
+     }
+   ]
+ }
+]

--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "CallToAction",
+    "schema": {
+      "title": "Call To Action Custom",
+      "description": "Get your 20% off on the first purchase!",
+      "type": "object",
+      "required": [
+        "title",
+        "link"
+      ],
+      "properties": {
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "link": {
+          "title": "Link Path",
+          "type": "object",
+          "required": [
+            "text",
+            "url"
+          ],
+          "properties": {
+            "text": {
+              "title": "Text",
+              "type": "string"
+            },
+            "url": {
+              "title": "URL",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "OurStores",
+    "schema": {
+      "title": "OurStores Custom Angela",
+      "description": "Search stores near to the users",
+      "type": "object",
+      "required": ["title", "description"],
+      "properties": {
+        "title": {
+          "title": "Title",
+          "type": "string",
+          "default": "Explore Nearby Stores"
+        },
+        "description": {
+          "title": "Link Path",
+          "type": "string",
+          "default": "Discover the closest store to you and pay us a visit."
+        }
+      }
+    }
+  }
+]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -54,9 +54,9 @@ module.exports = {
 
   previewRedirects: {
     home: '/',
-    plp: "/fresh%20food",
-    search: "/s?q=Fresh%20Produce",
-    pdp: "/triple-buffered-alenas/p",
+    plp: "/fresh-food",
+    search: "/s?q=metal",
+    pdp: "/triple-buffered-alenas-79/p",
   },
 
   // Lighthouse CI
@@ -64,8 +64,8 @@ module.exports = {
     server: process.env.BASE_SITE_URL || 'http://localhost:3000',
     pages: {
       home: '/',
-      pdp: "/triple-buffered-alenas/p",
-      collection: "/fresh%20food",
+      pdp: "/triple-buffered-alenas-79/p",
+      collection: "/vitrines",
     },
   },
 
@@ -73,10 +73,10 @@ module.exports = {
   cypress: {
     pages: {
       home: '/',
-      pdp: "/triple-buffered-alenas/p",
-      collection: "/fresh%20food",
-      collection_filtered: "/fresh%20food/?category-1=fresh%20food&brand=Fresh%20Produce&facets=category-1%2Cbrand%27",
-      search: "/s?q=Fresh%20Produce",
+      pdp: "/triple-buffered-alenas-79/p",
+      collection: "/vitrines",
+      collection_filtered: "/vitrines?category-1=fresh%20food&brand=Fresh%20Produce&facets=category-1%2Cbrand%27",
+      search: "/s?q=metal",
     },
     browser: 'electron',
   },

--- a/src/components/CallToAction/CallToAction.tsx
+++ b/src/components/CallToAction/CallToAction.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export interface CallToActionProps {
+  title: string;
+  link: {
+    text: string;
+    url: string;
+  };
+}
+
+export default function CallToAction(props: CallToActionProps) {
+  return (
+    <section>
+      <h2>{props.title}</h2>
+      <a href={props.link.url}>{props.link.text}</a>
+    </section>
+  );
+}

--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -1,0 +1,5 @@
+import CallToAction from './CallToAction'
+
+
+export default { CallToAction }
+

--- a/src/components/CustomBuyButton.tsx
+++ b/src/components/CustomBuyButton.tsx
@@ -1,0 +1,19 @@
+import { Button as UIButton } from '@faststore/ui'
+import { usePDP }  from "@faststore/core"
+
+export function CustomBuyButton() {
+  const context = usePDP()
+
+  return (
+    <UIButton
+      variant="primary"
+      onClick={() => {
+        alert(`Hello User: ${context.data.product.id}
+        \nCustom Field: ${context?.data?.product?.customData}
+        `)
+      }}
+    >
+      Click me!
+    </UIButton>
+  )
+}

--- a/src/components/OurStores/OurStores.tsx
+++ b/src/components/OurStores/OurStores.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Button, Icon, SelectField } from '@faststore/ui'
+
+export interface OurStoresProps {
+  title: string
+  description: string
+}
+
+export default function OurStores(props: OurStoresProps) {
+  return (
+    <section>
+      <h2>{props.title}</h2>
+      <p>{props.description}</p>
+      <div>
+        <SelectField
+          id="select-state-store"
+          label="State:"
+          options={{
+            newYork: 'New York',
+            arizona: 'Arizona',
+            massachusetts: 'Massachusetts',
+            hawaii: 'Hawaii',
+          }}
+        />
+        <SelectField
+          id="select-city-store"
+          label="City:"
+          options={{
+            newYorkCity: 'New York City',
+            phoenix: 'Phoenix',
+            boston: 'Boston',
+            honolulu: 'Honolulu',
+          }}
+        />
+        <Button
+          variant="secondary"
+          icon={<Icon name="ArrowRight" />}
+          iconPosition="right"
+        >
+          Find Store
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/OurStores/index.tsx
+++ b/src/components/OurStores/index.tsx
@@ -1,0 +1,3 @@
+import OurStores from './OurStores'
+
+export default { OurStores }

--- a/src/components/overrides/ProductDetails.tsx
+++ b/src/components/overrides/ProductDetails.tsx
@@ -1,0 +1,15 @@
+import { SectionOverride } from '@faststore/core'
+import { CustomBuyButton } from '../CustomBuyButton'
+
+const SECTION = 'ProductDetails' as const
+
+const override: SectionOverride = {
+  section: SECTION,
+  components: {
+    BuyButton: { Component: CustomBuyButton },
+  },
+
+}
+
+export { override }
+

--- a/src/fragments/ServerProduct.ts
+++ b/src/fragments/ServerProduct.ts
@@ -1,0 +1,9 @@
+import { gql } from '@faststore/core/api'
+
+export const fragment = gql(`
+fragment ServerProduct on Query {
+    product(locator: $locator) {
+      customData 
+    }
+  }
+`)

--- a/src/graphql/vtex/resolvers/index.ts
+++ b/src/graphql/vtex/resolvers/index.ts
@@ -1,0 +1,7 @@
+import { default as StoreProductResolver } from './product'
+
+const resolvers = {
+  ...StoreProductResolver,
+}
+
+export default resolvers

--- a/src/graphql/vtex/resolvers/product.ts
+++ b/src/graphql/vtex/resolvers/product.ts
@@ -1,0 +1,11 @@
+import type { StoreProductRoot } from '@faststore/core/api'
+
+const productResolver = {
+  StoreProduct: {
+    customData: (root: StoreProductRoot) => {
+      return root.itemId
+    },
+  },
+}
+
+export default productResolver

--- a/src/graphql/vtex/typeDefs/product.graphql
+++ b/src/graphql/vtex/typeDefs/product.graphql
@@ -1,0 +1,3 @@
+extend type StoreProduct {
+  customData: String!
+}

--- a/src/themes/soft-blue.scss
+++ b/src/themes/soft-blue.scss
@@ -10,13 +10,13 @@
   // --------------------------------------------------------
 
   // PALETTE
-  --fs-color-main-0: #E31C58;
+  --fs-color-main-0: #e6e6e6;
   --fs-color-main-1: #d8e2ff;
   --fs-color-main-2: #00419e;
   --fs-color-main-3: #002c71;
   --fs-color-main-4: #001947;
 
-  --fs-color-accent-0: #03aa27;
+  --fs-color-accent-0: #00ba92;
   --fs-color-accent-1: #8d50fd;
   --fs-color-accent-2: #732fe2;
   --fs-color-accent-3: #5900c8;

--- a/src/themes/soft-blue.scss
+++ b/src/themes/soft-blue.scss
@@ -63,7 +63,13 @@
   // --------------------------------------------------------
   // Add here the customizations for FastStore UI components.
 
-    --fs-logo-width: 8rem;
+  .section {
+    [data-fs-newsletter] {
+      --fs-newsletter-main-text-color: red;
+    }
+  }  
+  
+  --fs-logo-width: 10rem;
 
     [data-fs-product-card] {
       --fs-product-card-border-color: transparent;


### PR DESCRIPTION
## What's the purpose of this pull request?

Adding custom content-types, sections and api extensions following foresight videos

## How does it work?

content-types are the type of new pages i can create
sections are new components i can add using hCMS
fragments are extensions of the faststore apis to have more custom fields in the response 

## How to test it?

Go to the hCMS and verify if there is a custom page angela and if in each page you can find a Button custom angela

### Faststore related PRs


## References

